### PR TITLE
Fix: 3D旋转卡片悬停抖动问题

### DIFF
--- a/gallery/qml/Home/HomePage.qml
+++ b/gallery/qml/Home/HomePage.qml
@@ -335,7 +335,47 @@ Rectangle {
                     required property string name
                     required property string desc
 
+                    property bool preventFlicker: false
+
                     Behavior on width { NumberAnimation { duration: DelTheme.Primary.durationMid } }
+
+                    MouseArea {
+                        id: hoverArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        acceptedButtons: Qt.NoButton
+                        
+                        onEntered: {
+                            if (!__card.hovered) {
+                                __card.hovered = true;
+                                preventFlicker = true;
+                                flickerTimer.restart();
+                            }
+                        }
+                        
+                        onExited: {
+                            if (!__card.containsMouse) {
+                                __card.hovered = false;
+                            }
+                        }
+                    }
+                    
+                    Timer {
+                        id: flickerTimer
+                        interval: DelTheme.Primary.durationMid * 1.5
+                        onTriggered: {
+                            __rootItem.preventFlicker = false;
+                        }
+                    }
+                    
+                    Connections {
+                        target: __card
+                        function onContainsMouseChanged() {
+                            if (__card.containsMouse) {
+                                __card.hovered = true;
+                            }
+                        }
+                    }
 
                     Card {
                         id: __card


### PR DESCRIPTION
修复示例中首页底部3D卡片的抖动问题。
前：
![449302987-d710c459-e555-48dd-ab01-66f9d3fb3bce](https://github.com/user-attachments/assets/42f45b36-73eb-48e2-952a-85b6017a20ea)
后：
![449301862-8776f0a2-6698-47e5-b31f-5d44fa14a28e](https://github.com/user-attachments/assets/fcb8c985-b4ad-494a-b543-ee6c673d5f9e)
