### PR TITLE
Feat: 增加几个过渡效果

### DIFF
--- a/gallery/qml/Examples/DataDisplay/ExpTourFocus.qml
+++ b/gallery/qml/Examples/DataDisplay/ExpTourFocus.qml
@@ -23,6 +23,7 @@ Flickable {
 支持的属性：\n
 属性名 | 类型 | 描述
 ------ | --- | ---
+animationEnabled | bool | 是否开启动画(默认true)
 target | Item | 焦点目标
 overlayColor | color | 覆盖层颜色
 focusMargin | int | 焦点边距

--- a/src/imports/DelegateUI/Controls/DelRate.qml
+++ b/src/imports/DelegateUI/Controls/DelRate.qml
@@ -34,20 +34,37 @@ Item {
     property int fillIcon: DelIcon.StarFilled
     property int emptyIcon: DelIcon.StarFilled
     property int halfIcon: DelIcon.StarFilled
+    /* 是否支持半星动画 */
+    property bool supportsHalfAnimation: allowHalf && ((fillIcon === DelIcon.StarFilled && emptyIcon === DelIcon.StarFilled) || halfIcon !== emptyIcon)
     property Component fillDelegate: DelIconText {
         colorIcon: control.colorFill
         iconSource: control.fillIcon
         iconSize: control.iconSize
+        
+        Behavior on opacity {
+            enabled: control.animationEnabled
+            NumberAnimation { duration: DelTheme.Primary.durationFast }
+        }
     }
     property Component emptyDelegate: DelIconText {
         colorIcon: control.colorEmpty
         iconSource: control.emptyIcon
         iconSize: control.iconSize
+        
+        Behavior on opacity {
+            enabled: control.animationEnabled
+            NumberAnimation { duration: DelTheme.Primary.durationFast }
+        }
     }
     property Component halfDelegate: DelIconText {
         colorIcon: control.colorEmpty
         iconSource: control.emptyIcon
         iconSize: control.iconSize
+        
+        Behavior on opacity {
+            enabled: control.animationEnabled
+            NumberAnimation { duration: DelTheme.Primary.durationFast }
+        }
 
         DelIconText {
             id: __source
@@ -56,6 +73,16 @@ Item {
             iconSize: control.iconSize
             layer.enabled: true
             layer.effect: halfRateHelper
+            
+            Behavior on opacity {
+                enabled: control.animationEnabled
+                NumberAnimation { duration: DelTheme.Primary.durationFast }
+            }
+            
+            Behavior on width {
+                enabled: control.animationEnabled
+                NumberAnimation { duration: DelTheme.Primary.durationFast }
+            }
         }
     }
     property Component toolTipDelegate: Item {
@@ -63,7 +90,7 @@ Item {
         height: 6
         opacity: hovered ? 1 : 0
 
-        Behavior on opacity { enabled: control.animationEnabled; NumberAnimation { duration: DelTheme.Primary.durationMid } }
+        Behavior on opacity { enabled: control.animationEnabled; NumberAnimation { duration: DelTheme.Primary.durationFast } }
 
         MultiEffect {
             anchors.fill: __item
@@ -160,7 +187,17 @@ Item {
 
                 property int fillCount: Math.floor(control.value)
                 property int emptyStartIndex: Math.round(control.value)
-                property bool hasHalf: control.value - fillCount > 0
+                property bool hasHalf: control.allowHalf && control.value - fillCount > 0 && control.supportsHalfAnimation
+                
+                Behavior on fillCount {
+                    enabled: control.animationEnabled
+                    NumberAnimation { duration: DelTheme.Primary.durationFast }
+                }
+                
+                Behavior on emptyStartIndex {
+                    enabled: control.animationEnabled
+                    NumberAnimation { duration: DelTheme.Primary.durationFast }
+                }
 
                 model: control.count
                 delegate: MouseArea {
@@ -170,7 +207,12 @@ Item {
                     hoverEnabled: true
                     cursorShape: hovered ? control.hoverCursorShape : Qt.ArrowCursor
                     enabled: control.enabled
-                    onEntered: hovered = true;
+                    onEntered: {
+                        hovered = true;
+                        if (control.animationEnabled) {
+                            __scaleAnim.start();
+                        }
+                    }
                     onExited: hovered = false;
                     onClicked: {
                         control.isDone = !control.isDone;
@@ -180,39 +222,97 @@ Item {
                         }
                     }
                     onPositionChanged: function(mouse) {
+                        let newValue;
                         if (control.allowHalf) {
                             if (mouse.x > (width * 0.5)) {
-                                control.value = index + 1;
+                                newValue = index + 1;
                             } else {
-                                control.value = index + 0.5;
+                                newValue = index + 0.5;
                             }
-
                         } else {
-                            control.value = index + 1;
+                            newValue = index + 1;
+                        }
+                        
+                        // 只有当评分值变化时才触发动画
+                        if (newValue !== control.value) {
+                            control.value = newValue;
+                            if (control.animationEnabled && !__scaleAnim.running) {
+                                __scaleAnim.start();
+                            }
                         }
                     }
                     required property int index
                     property bool hovered: false
 
-                    Loader {
-                        active: index < __repeater.fillCount
-                        sourceComponent: control.fillDelegate
-                        property int index: __rootItem.index
-                        property bool hovered: __rootItem.hovered
+                    SequentialAnimation {
+                        id: __scaleAnim
+                        NumberAnimation {
+                            target: __rootItemContainer
+                            property: "scale"
+                            from: 1.0
+                            to: 1.15
+                            duration: 100
+                            easing.type: Easing.OutQuad
+                        }
+                        NumberAnimation {
+                            target: __rootItemContainer
+                            property: "scale"
+                            from: 1.15
+                            to: 1.0
+                            duration: 100
+                            easing.type: Easing.OutBounce
+                        }
                     }
 
-                    Loader {
-                        active: __repeater.hasHalf && index === (__repeater.emptyStartIndex - 1)
-                        sourceComponent: control.halfDelegate
-                        property int index: __rootItem.index
-                        property bool hovered: __rootItem.hovered
-                    }
+                    Item {
+                        id: __rootItemContainer
+                        width: parent.width
+                        height: parent.height
+                        
+                        Loader {
+                            id: fillLoader
+                            anchors.fill: parent
+                            active: true
+                            opacity: index < __repeater.fillCount ? 1.0 : 0.0
+                            sourceComponent: control.fillDelegate
+                            property int index: __rootItem.index
+                            property bool hovered: __rootItem.hovered
+                            
+                            Behavior on opacity {
+                                enabled: control.animationEnabled
+                                NumberAnimation { duration: DelTheme.Primary.durationFast }
+                            }
+                        }
 
-                    Loader {
-                        active: index >= __repeater.emptyStartIndex
-                        sourceComponent: control.emptyDelegate
-                        property int index: __rootItem.index
-                        property bool hovered: __rootItem.hovered
+                        Loader {
+                            id: halfLoader
+                            anchors.fill: parent
+                            active: control.allowHalf && control.supportsHalfAnimation
+                            opacity: __repeater.hasHalf && index === (__repeater.emptyStartIndex - 1) ? 1.0 : 0.0
+                            sourceComponent: control.halfDelegate
+                            property int index: __rootItem.index
+                            property bool hovered: __rootItem.hovered
+                            
+                            Behavior on opacity {
+                                enabled: control.animationEnabled && control.supportsHalfAnimation
+                                NumberAnimation { duration: DelTheme.Primary.durationFast }
+                            }
+                        }
+
+                        Loader {
+                            id: emptyLoader
+                            anchors.fill: parent
+                            active: true
+                            opacity: index >= __repeater.emptyStartIndex ? 1.0 : 0.0
+                            sourceComponent: control.emptyDelegate
+                            property int index: __rootItem.index
+                            property bool hovered: __rootItem.hovered
+                            
+                            Behavior on opacity {
+                                enabled: control.animationEnabled
+                                NumberAnimation { duration: DelTheme.Primary.durationFast }
+                            }
+                        }
                     }
 
                     Loader {

--- a/src/imports/DelegateUI/Controls/DelTableView.qml
+++ b/src/imports/DelegateUI/Controls/DelTableView.qml
@@ -836,6 +836,8 @@ DelRectangle {
                                                                        DelTheme.DelTableView.colorCellBgHover : DelTheme.DelTableView.colorCellBg;
                     }
                 }
+                
+                Behavior on color { enabled: control.animationEnabled; ColorAnimation { duration: DelTheme.Primary.durationFast } }
 
                 TableView.onReused: {
                     checked = __private.checkedKeysMap.has(key);

--- a/src/imports/DelegateUI/Controls/DelTimePicker.qml
+++ b/src/imports/DelegateUI/Controls/DelTimePicker.qml
@@ -156,10 +156,31 @@ T.TextField {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                 }
-                background: Rectangle {
-                    radius: 4
-                    color: hovered ? DelTheme.DelTimePicker.colorButtonBgHover :
-                                     checked ? DelTheme.DelTimePicker.colorButtonBgActive : 'transparent'
+                background: Item {
+                    Rectangle {
+                        id: selectionRect
+                        anchors.fill: parent
+                        radius: 4
+                        color: DelTheme.DelTimePicker.colorButtonBgActive
+                        opacity: checked ? 1.0 : 0.0
+                        
+                        Behavior on opacity {
+                            enabled: control.animationEnabled && !checked
+                            NumberAnimation { duration: DelTheme.Primary.durationFast }
+                        }
+                    }
+                    
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 4
+                        color: hovered && !checked ? DelTheme.DelTimePicker.colorButtonBgHover : "transparent"
+                        z: -1
+                        
+                        Behavior on color { 
+                            enabled: control.animationEnabled
+                            ColorAnimation { duration: DelTheme.Primary.durationFast }
+                        }
+                    }
                 }
                 T.ButtonGroup.group: __buttonGroup
                 onClicked: {
@@ -279,24 +300,54 @@ T.TextField {
         }
     }
 
+    // 时钟图标
     DelIconText {
+        id: clockIcon
         anchors.left: control.iconPosition == DelTimePicker.Position_Left ? parent.left : undefined
         anchors.right: control.iconPosition == DelTimePicker.Position_Right ? parent.right : undefined
         anchors.margins: 5
         anchors.verticalCenter: parent.verticalCenter
-        iconSource: (control.hovered && control.length !== 0) ? DelIcon.CloseCircleFilled : DelIcon.ClockCircleOutlined
+        iconSource: DelIcon.ClockCircleOutlined
         iconSize: control.iconSize
         colorIcon: control.enabled ?
-                       __iconMouse.hovered ? DelTheme.DelTimePicker.colorIconHover :
-                                             DelTheme.DelTimePicker.colorIcon : DelTheme.DelTimePicker.colorIconDisabled
-
+                   __iconMouse.hovered ? DelTheme.DelTimePicker.colorIconHover :
+                                        DelTheme.DelTimePicker.colorIcon : DelTheme.DelTimePicker.colorIconDisabled
+        opacity: (control.hovered && control.length !== 0) ? 0.0 : 1.0
+        
+        Behavior on opacity { 
+            enabled: control.animationEnabled
+            NumberAnimation { duration: DelTheme.Primary.durationFast }
+        }
+        
         Behavior on colorIcon { enabled: control.animationEnabled; ColorAnimation { duration: DelTheme.Primary.durationFast } }
-
+    }
+    
+    // 清除按钮图标
+    DelIconText {
+        id: clearIcon
+        anchors.left: control.iconPosition == DelTimePicker.Position_Left ? parent.left : undefined
+        anchors.right: control.iconPosition == DelTimePicker.Position_Right ? parent.right : undefined
+        anchors.margins: 5
+        anchors.verticalCenter: parent.verticalCenter
+        iconSource: DelIcon.CloseCircleFilled
+        iconSize: control.iconSize
+        colorIcon: control.enabled ?
+                   __iconMouse.hovered ? DelTheme.DelTimePicker.colorIconHover :
+                                        DelTheme.DelTimePicker.colorIcon : DelTheme.DelTimePicker.colorIconDisabled
+        opacity: (control.hovered && control.length !== 0) ? 1.0 : 0.0
+        
+        Behavior on opacity { 
+            enabled: control.animationEnabled
+            NumberAnimation { duration: DelTheme.Primary.durationFast }
+        }
+        
+        Behavior on colorIcon { enabled: control.animationEnabled; ColorAnimation { duration: DelTheme.Primary.durationFast } }
+        
         MouseArea {
             id: __iconMouse
             anchors.fill: parent
             hoverEnabled: true
-            cursorShape: parent.iconSource == DelIcon.CloseCircleFilled ? Qt.PointingHandCursor : Qt.ArrowCursor
+            cursorShape: (control.hovered && control.length !== 0) ? Qt.PointingHandCursor : Qt.ArrowCursor
             onEntered: hovered = true;
             onExited: hovered = false;
             onClicked: {

--- a/src/imports/DelegateUI/Controls/DelTourFocus.qml
+++ b/src/imports/DelegateUI/Controls/DelTourFocus.qml
@@ -5,11 +5,22 @@ import DelegateUI
 T.Popup {
     id: control
 
+    property bool animationEnabled: DelTheme.animationEnabled
     property Item target: null
     property color colorOverlay: DelTheme.DelTour.colorOverlay
     property real focusMargin: 5
 
-    onAboutToShow: __private.recalcPosition();
+    onAboutToShow: {
+        __private.recalcPosition();
+        opacity = 1.0;
+    }
+
+    onAboutToHide: {
+        if (control.animationEnabled && !__private.isClosing && opacity > 0) {
+            visible = true;
+            __private.startClosing();
+        }
+    }
 
     QtObject {
         id: __private
@@ -17,15 +28,60 @@ T.Popup {
         property real focusY: 0
         property real focusWidth: control.target ? (control.target.width + control.focusMargin * 2) : 0
         property real focusHeight: control.target ? (control.target.height + control.focusMargin * 2) : 0
+        property bool isClosing: false
+        
         function recalcPosition() {
             if (!control.target) return;
             const pos = control.target.mapToItem(null, 0, 0);
             focusX = pos.x - control.focusMargin;
             focusY = pos.y - control.focusMargin;
         }
+        
+        function startClosing() {
+            if (isClosing) return;
+            isClosing = true;
+            __closeAnimation.restart();
+        }
     }
 
+    closePolicy: T.Popup.CloseOnEscape | T.Popup.CloseOnPressOutside
+    
+    function close() {
+        if (!visible || __private.isClosing) return;
+        if (control.animationEnabled) {
+            __private.startClosing();
+        } else {
+            control.visible = false;
+        }
+    }
+
+    NumberAnimation {
+        id: __closeAnimation
+        target: control
+        property: "opacity"
+        from: 1.0
+        to: 0.0
+        duration: control.animationEnabled ? DelTheme.Primary.durationMid : 0
+        easing.type: Easing.InOutQuad
+        onFinished: {
+            __private.isClosing = false;
+            control.visible = false;
+        }
+    }
+
+    enter: Transition {
+        NumberAnimation {
+            property: "opacity";
+            from: 0.0
+            to: 1.0
+            duration: control.animationEnabled ? DelTheme.Primary.durationMid : 0
+        }
+    }
+
+    exit: null
+
     T.Overlay.modal: Item {
+        id: modalOverlay
         onWidthChanged: __private.recalcPosition();
         onHeightChanged: __private.recalcPosition();
 
@@ -33,6 +89,7 @@ T.Popup {
             id: source
             color: control.colorOverlay
             anchors.fill: parent
+            opacity: control.opacity
             layer.enabled: true
             layer.effect: ShaderEffect {
                 property real xMin: __private.focusX / source.width


### PR DESCRIPTION
发现几个组件没有过渡动画。虽然是无关紧要的问题，但是对于我来说看着十分难受。

修改了以下几个组件：
1.漫游焦点（蒙版淡入淡出）
前：
![动画](https://github.com/user-attachments/assets/2cadee13-c527-45ef-a937-82d118463f1e)
后：
![动画2](https://github.com/user-attachments/assets/512c8aca-8b9b-4475-bdc5-7000d124d054)
2.漫游式引导（同上）
前：
![动画3](https://github.com/user-attachments/assets/c4f53b2f-4c03-4d68-9c51-6a8be8f96437)
后：
![动画4](https://github.com/user-attachments/assets/47271a7b-0f86-45d2-ba4b-bf861d6567d3)
3.表格（鼠标悬停）
前：
![动画5](https://github.com/user-attachments/assets/6a285c7f-1c47-4ac2-be43-59ea06e4e219)
后：
![动画6](https://github.com/user-attachments/assets/23ce47a5-9f78-4d29-9f81-1ea3947dc14b)
4.评分（增减）
前：
![动画7](https://github.com/user-attachments/assets/7da9803e-9f12-47f0-95f4-5f7d82a5ef5e)
后：
![动画8](https://github.com/user-attachments/assets/0fdf4fea-bf8c-402d-9449-67eb7b5ac078)
5.多选框（打勾动画）
前：
![动画9](https://github.com/user-attachments/assets/6dfaa7d9-269e-4d99-9a9b-3bf1176ee684)
后：
![动画10](https://github.com/user-attachments/assets/eda4d63a-a266-4828-923d-c37082956613)


注：
1.上述组件均支持动画开关.
2.我闲的没事写的，不保证质量。但是上述问题希望重视一下，毕竟大佬动动手指就能解决我这样强迫症的苦恼。
3.还有两个希望完善的动画：DelAutoComplete列表上鼠标悬停、DelPagination页码上的鼠标悬停和页码切换。
4.顺便问一下：大佬打不打算开发python版本的？