### PR TITLE
fix(gallery): 修复窗口特效切换失败时单选按钮状态未同步的问题

### DIFF
--- a/gallery/qml/Home/SettingsPage.qml
+++ b/gallery/qml/Home/SettingsPage.qml
@@ -331,12 +331,15 @@ HusWindow {
 
                         Repeater {
                             delegate: HusRadio {
+                                property int effectValue: modelData.value
                                 text: modelData.label
                                 ButtonGroup.group: specialEffectGroup
                                 onClicked: {
-                                    let oldEffect = galleryWindow.specialEffect;
                                     if (!galleryWindow.setSpecialEffect(modelData.value)) {
-                                        galleryWindow.setSpecialEffect(oldEffect);
+                                        for (let i = 0; i < specialEffectGroup.buttons.length; i++) {
+                                            specialEffectGroup.buttons[i].checked =
+                                                specialEffectGroup.buttons[i].effectValue === galleryWindow.specialEffect;
+                                        }
                                     }
                                 }
                                 Component.onCompleted: {


### PR DESCRIPTION
在设置页面的「窗口效果」部分，当用户选择某个窗口特效（如云母、亚克力等）但系统不支持该特效导致 setSpecialEffect 返回 false 时，单选按钮的选中状态与实际生效的窗口特效不一致。
ButtonGroup 在 onClicked 触发前就已自动更新了单选按钮的 checked 状态。原代码在失败后尝试调用 setSpecialEffect(oldEffect) 恢复，但由于 specialEffect 属性实际上从未被修改（失败时函数直接返回 false），此调用等同于空操作，无法触发 UI 状态回退。