### PR TITLE
docs: 修复中英文README中失效的Star历史图表

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -204,4 +204,4 @@ Windows 11 / Ubuntu 24.04.2, Qt Version >= 6.7
 
 ## 🎉 Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mengps/HuskarUI&type=Date)](https://star-history.com/#mengps/HuskarUI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mengps/HuskarUI&type=Date)](https://star-history.dera.page/#mengps/HuskarUI&Date)

--- a/README.md
+++ b/README.md
@@ -203,4 +203,4 @@ Windows 11 / Ubuntu 24.04.2, Qt Version >= 6.7
 
 ## 🎉 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mengps/HuskarUI&type=Date)](https://star-history.com/#mengps/HuskarUI&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mengps/HuskarUI&type=Date)](https://star-history.dera.page/#mengps/HuskarUI&Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表已经失效，无法正常展示项目星标趋势。

本 PR 将中英文 README 中的 Star 历史图表链接更新为可用的新地址，恢复图表的正常显示，便于关注者了解项目发展情况。

涉及的修改：
- README.md
- README-zh_CN.md